### PR TITLE
Default to compatibility font

### DIFF
--- a/build-container-podman.sh
+++ b/build-container-podman.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+podman build -t text-security-font-builder .

--- a/build-fonts-podman.sh
+++ b/build-fonts-podman.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+mkdir -p output
+
+podman run \
+  -v "$(pwd)/src":/src:z \
+  -v "$(pwd)/output":/output:z \
+  text-security-font-builder python /src/generate-fonts.py $1

--- a/src/style-template.css
+++ b/src/style-template.css
@@ -1,7 +1,28 @@
 @font-face {
   font-family: 'text-security';
   src: url('text-security-compat.eot');
+  /*
+   Hack to prevent Firefox from loading the compatibility fonts.
+   Without this, ff will download both compatibility and optimized fonts
+   even though only the optimized version is needed. Bug in ff?
+  */
+  font-style: oblique;
   src: url('text-security-compat.eot?#iefix') format('embedded-opentype'),
-      url('text-security.woff2') format('woff2'),
+      url('text-security-compat.woff2') format('woff2'),
       url('text-security-compat.ttf') format('truetype');
+}
+
+/*
+  Browser detection hack to enable the optimized font in recent versions of Chromium and FF,
+  which implement their own font rendering and do support cmap format 13.
+
+  content-visibility is currently only supported in Chrome & Edge version 85+ & Chrome for Android
+  -moz-is-html only lets Firefox through
+  -webkit-hyphens explicitly excludes Safari in case they later add support for content-visibility
+*/
+@supports ((content-visibility: visible) or selector(:-moz-is-html)) and (not (-webkit-hyphens:none)) {
+  @font-face {
+    font-family: 'text-security';
+    src: url('text-security.woff2') format('woff2'), url('text-security-compat.ttf') format('truetype');
+  }
 }

--- a/src/style-template.css
+++ b/src/style-template.css
@@ -1,12 +1,6 @@
 @font-face {
   font-family: 'text-security';
   src: url('text-security-compat.eot');
-  /*
-   Hack to prevent Firefox from loading the compatibility fonts.
-   Without this, ff will download both compatibility and optimized fonts
-   even though only the optimized version is needed. Bug in ff?
-  */
-  font-style: oblique;
   src: url('text-security-compat.eot?#iefix') format('embedded-opentype'),
       url('text-security-compat.woff2') format('woff2'),
       url('text-security-compat.ttf') format('truetype');
@@ -20,9 +14,10 @@
   -moz-is-html only lets Firefox through
   -webkit-hyphens explicitly excludes Safari in case they later add support for content-visibility
 */
-@supports ((content-visibility: visible) or selector(:-moz-is-html)) and (not (-webkit-hyphens:none)) {
+@supports ((content-visibility: visible) or selector(:-moz-is-html)) and (not (-webkit-hyphens: none)) {
   @font-face {
     font-family: 'text-security';
-    src: url('text-security.woff2') format('woff2'), url('text-security-compat.ttf') format('truetype');
+    src: url('text-security.woff2') format('woff2'),
+      url('text-security-compat.ttf') format('truetype');
   }
 }


### PR DESCRIPTION
Fix #10 
Fix #12 
Fix #13 

Use the compatibility font by default and only enable the optimized font in browsers where it's been tested to wok. I.e. Chromium and Firefox.
